### PR TITLE
Two bug fixes and an enhancement

### DIFF
--- a/dis68k.c
+++ b/dis68k.c
@@ -1212,10 +1212,23 @@ void datadump(uint32_t start, uint32_t end) {
 		const uint32_t reamaining_bytes = end - address;
 		const int  bytes_to_print = (reamaining_bytes > 16) ? 16 : reamaining_bytes;
 
-		for (int i = 0; i < bytes_to_print; ++i) {
-			const int byte = getbyte();
-			printf("%c ", isprint(byte) ? byte : '.');
-		}
+                int toprint[16] ;
+                for (int i = 0; i < 16; ++i) {
+                        if (i >= bytes_to_print)
+                               printf("   ") ;
+                        else
+                               toprint[i] = getbyte() ;
+                }
+                printf("  ") ;
+                for (int i = 0; i < 16; ++i) {
+                        const int byte = toprint[i] ;
+                        if (i >= bytes_to_print)
+                                printf(" ") ;
+                        else if (isprint(byte))
+                                printf("%c", byte) ;
+                        else
+                                printf(".") ;
+                }
 		fputc('\n', stdout);
 	}
 }

--- a/dis68k.c
+++ b/dis68k.c
@@ -845,8 +845,11 @@ void disasm(unsigned long int start, unsigned long int end) {
 						*/
 
 						/* check for illegal modes */
-						if ((smode == 1) && (size == 1)) break;
-						if ((smode == 9) || (smode == 10)) break;
+						// smode=1, size=1 is legal; 36 0d
+						// if ((smode == 1) && (size == 1)) break;
+						// smode=9 is legal; 2d 40 ff ec
+						// smode=10 is legal; 30 3b 00 00
+						// if ((smode == 9) || (smode == 10)) break;
 						if (smode > 11) break;
 						if (dmode == 1) break;
 						if (dmode >= 9) break;

--- a/dis68k.c
+++ b/dis68k.c
@@ -1177,7 +1177,7 @@ void disasm(unsigned long int start, unsigned long int end) {
 			if (decoded) opnum = 88;
 		}
 
-		const uint32_t fetched = address - start_address;
+		const int fetched = address - start_address;
 		if (!rawmode) {
 			for (int i = 0 ; i < (5 - fetched); ++i) printf("     ");
 		}


### PR DESCRIPTION
Three commits to consider.

The first one fixes a bug where certain inputs can cause an infinite loop, because an unsigned int is used to hold a limit, and 5-unsigned is always nonnegative.

The second fixes some decoding; example instructions are given in the comments justifying the change.  For an online 68K decode see https://onlinedisassembler.com/odaweb/, for example.

The third improves the way data sections are displayed, separating the hex dump and the ASCII dump so the ASCII dump can be more easily read.  This also makes the output fit in a standard terminal window.