### PR TITLE
use format specifier 'x' when prefixing the output with '$'

### DIFF
--- a/dis68k.c
+++ b/dis68k.c
@@ -221,7 +221,7 @@ void sprintmode(unsigned int mode, unsigned int reg, unsigned int size, char *ou
 			} else {
 				const uint32_t ldata = address - 2 + displacement;
 				if (!rawmode) {
-					sprintf(out_s, "%+i(PC) {$%08u}", displacement, ldata);
+					sprintf(out_s, "%+i(PC) {$%08x}", displacement, ldata);
 				} else {
 					sprintf(out_s, "%+i(PC)", displacement);
 				}


### PR DESCRIPTION
When printing the computed absolute address for PC-relative addressing, the decimal format specifier 'u' was used, but the result was prefixed with '$'. This patch fixes this.
